### PR TITLE
Added support to load TGA images from GLTF

### DIFF
--- a/amethyst_gltf/src/format/importer.rs
+++ b/amethyst_gltf/src/format/importer.rs
@@ -10,6 +10,7 @@ use crate::error;
 pub enum ImageFormat {
     Png,
     Jpeg,
+    Tga,
 }
 
 impl ImageFormat {
@@ -17,6 +18,7 @@ impl ImageFormat {
         match mime {
             "image/jpeg" => ImageFormat::Jpeg,
             "image/png" => ImageFormat::Png,
+            "image/tga" => ImageFormat::Tga,
             _ => unreachable!(),
         }
     }
@@ -185,6 +187,7 @@ pub fn get_image_data(
                     let format = match &ext[..] {
                         "jpg" | "jpeg" => ImageFormat::Jpeg,
                         "png" => ImageFormat::Png,
+                        "tga" => ImageFormat::Tga,
                         _ => unreachable!(),
                     };
                     Ok((data, format))

--- a/amethyst_gltf/src/format/material.rs
+++ b/amethyst_gltf/src/format/material.rs
@@ -154,6 +154,7 @@ fn load_texture(
         format: match format {
             ImportDataFormat::Png => Some(DataFormat::PNG),
             ImportDataFormat::Jpeg => Some(DataFormat::JPEG),
+            ImportDataFormat::Tga => Some(DataFormat::TGA),
         },
         sampler_info: load_sampler_info(&texture.sampler()),
         ..Default::default()


### PR DESCRIPTION
## Description

Added support for `amethyst_gltf` to import `Targa` (`.tga`) images from `gltf`/`glb` files.

## Additions

- None

## Removals

- None

## Modifications

- Added `tga` to an enum and it's respective match cases. Amethyst's already existing texture API takes care of the rest.

## PR Checklist

By placing an x in the boxes I certify that I have:

- [x] Updated the content of the book if this PR would make the book outdated.
- [ ] Added a changelog entry if this will impact users, or modified more than 5 lines of Rust that wasn't a doc comment.
- [ ] Added unit tests for new code added in this PR.
- [x] Acknowledged that by making this pull request I release this code under an MIT/Apache 2.0 dual licensing scheme.

If this modified or created any rs files:

- [x] Ran `cargo +stable fmt --all`
- [x] Ran `cargo clippy --all --features "empty"`
- [x] Ran `cargo test --all --features "empty"`
